### PR TITLE
Make LFS for test files optional

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[lfs]
+	fetchexclude = *

--- a/ios/sample_app/ui_test_suite.sh
+++ b/ios/sample_app/ui_test_suite.sh
@@ -39,6 +39,13 @@ runTest()
   fi
 }
 
+echo "Pulling snapshot test files from Git LFS."
+git lfs pull --include="*" --exclude=""
+if $? -ne 0; then
+  echo "Error pulling snapshot test files from Git LFS. Exiting. Make sure you have git-lfs installed."
+  exit 99
+fi
+
 # iPhone 15 Plus, iOS 17.0
 runTest 'platform=iOS Simulator,OS=17.0,name=iPhone 15 Plus'
 


### PR DESCRIPTION
SPM doesn't work with LFS out of the box. https://forums.swift.org/t/swiftpm-with-git-lfs/42396

We don't want extra steps to install our package. LFS only included files needed for snapshot tests, so this change does a few things:

 - by default, git will just checkout the pointer files, not the full LFS file. see .lfsconfig
 - The snapshot test script pulls these file explicitly if missing

This **seems** to work, but moving to main to confirm.