### PR TITLE
PropsDB Progress

### DIFF
--- a/go/appcore/appcore.go
+++ b/go/appcore/appcore.go
@@ -48,6 +48,7 @@ func NewAppcore() *Appcore {
 	return &Appcore{
 		propertyRegistry:    newPropertyRegistry(),
 		seenNamedConditions: map[string]string{},
+		db:                  db.NewDB(),
 	}
 }
 
@@ -118,13 +119,12 @@ func (ac *Appcore) SetDataDirPath(dataDirPath string) (returnErr error) {
 	}
 	ac.cache = cache
 
-	db, err := db.NewDB(dataDirPath)
+	err = ac.db.StartWithPath(dataDirPath)
 	if err != nil {
 		return err
 	}
-	ac.db = db
 
-	dbOperations := db.EventManager().EventManagerConditionFunctions()
+	dbOperations := ac.db.EventManager().EventManagerConditionFunctions()
 	ac.propertyRegistry.RegisterDynamicFunctions(dbOperations)
 
 	return nil

--- a/go/appcore/appcore_test.go
+++ b/go/appcore/appcore_test.go
@@ -99,8 +99,8 @@ func buildTestAppCoreWithPath(path string, t *testing.T) (*Appcore, error) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ac.db == nil || ac.db.EventManager() == nil || ac.cache == nil {
-		t.Fatal("db, event manager, or cache not setup")
+	if ac.db == nil || ac.db.EventManager() == nil || ac.db.PropertyHistoryManager() == nil || ac.cache == nil {
+		t.Fatal("db, event manager, prop history manager, or cache not setup")
 	}
 	lb := testLibBindings{}
 	ac.RegisterLibraryBindings(&lb)

--- a/go/appcore/db/event_manager_test.go
+++ b/go/appcore/db/event_manager_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 func testEventManager(path string) (*EventManager, error) {
-	db, err := NewDB(path)
+	db := NewDB()
+	err := db.StartWithPath(path)
 	if err != nil {
 		return nil, err
 	}

--- a/go/appcore/db/property_history_manager.go
+++ b/go/appcore/db/property_history_manager.go
@@ -1,0 +1,82 @@
+package db
+
+import (
+	"errors"
+
+	datamodel "github.com/CriticalMoments/CriticalMoments/go/cmcore/data_model"
+)
+
+type propHistoryValue struct {
+	value       interface{}
+	sample_type datamodel.CMPropertySampleType
+}
+
+type PropertyHistoryManager struct {
+	db *DB
+
+	preStartPropsCache map[string]propHistoryValue
+}
+
+func newPropertyHistoryManager(db *DB) *PropertyHistoryManager {
+	return &PropertyHistoryManager{
+		db:                 db,
+		preStartPropsCache: map[string]propHistoryValue{},
+	}
+}
+
+func (phm *PropertyHistoryManager) TrackPropertyHistoryForStartup(appStartValues map[string]interface{}) error {
+	// keep processing on error, but return all errors at end
+	errorSet := []error{}
+
+	// Set values for properties that were set before startup
+	for name, prop := range phm.preStartPropsCache {
+		err := phm.db.InsertPropertyHistory(name, prop.value, prop.sample_type)
+		if err != nil {
+			errorSet = append(errorSet, err)
+		}
+	}
+	phm.preStartPropsCache = map[string]propHistoryValue{}
+
+	// Set the startup values (used for built in props with sample type= CMPropertySampleTypeAppStart)
+	for name, val := range appStartValues {
+		err := phm.db.InsertPropertyHistory(name, val, datamodel.CMPropertySampleTypeAppStart)
+		if err != nil {
+			errorSet = append(errorSet, err)
+		}
+	}
+
+	if len(errorSet) > 0 {
+		return errors.Join(errorSet...)
+	}
+
+	return nil
+}
+
+func (phm *PropertyHistoryManager) CustomPropertySet(name string, val interface{}) error {
+	return phm.setPropertyHistory(name, val, datamodel.CMPropertySampleTypeOnCustomSet)
+}
+
+func (phm *PropertyHistoryManager) UpdateHistoryForPropertyAccessed(name string, val interface{}) error {
+	return phm.setPropertyHistory(name, val, datamodel.CMPropertySampleTypeOnUse)
+}
+
+func (phm *PropertyHistoryManager) setPropertyHistory(name string, val interface{}, sampleType datamodel.CMPropertySampleType) error {
+	if name == "" {
+		return nil
+	}
+
+	if phm.db.started {
+		err := phm.db.InsertPropertyHistory(name, val, datamodel.CMPropertySampleTypeOnCustomSet)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Not started, cache
+		phm.preStartPropsCache[name] = propHistoryValue{
+			value:       val,
+			sample_type: sampleType,
+		}
+	}
+
+	return nil
+}

--- a/go/appcore/db/property_history_manager_test.go
+++ b/go/appcore/db/property_history_manager_test.go
@@ -1,0 +1,207 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+)
+
+func testPropertyHistoryManager(t testing.TB) (*DB, *PropertyHistoryManager, error) {
+	dataPath := fmt.Sprintf("/tmp/criticalmoments/test-temp-%v", rand.Int())
+	err := os.MkdirAll(dataPath, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := NewDB()
+	err = db.StartWithPath(dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return db, newPropertyHistoryManager(db), nil
+}
+
+// Test all permutations of property types with sample_type, and when they can be set (before/after startup)
+func TestHistoryManager(t *testing.T) {
+	dataPath := fmt.Sprintf("/tmp/criticalmoments/test-temp-%v", rand.Int())
+	err := os.MkdirAll(dataPath, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := NewDB()
+	phm := db.PropertyHistoryManager()
+
+	baseProps := map[string]interface{}{
+		"Text1":     "custom1val",
+		"Text2":     "custom2val",
+		"TextEmpty": "",
+		"Int":       123,
+		"IntZero":   0,
+		"IntNeg":    -984594854958,
+		"Float":     123.456,
+		"FloatZero": 0.0,
+		"FloatNeg":  -3498534958349.934,
+		"BoolTrue":  true,
+		"BoolFalse": false,
+		"TimeNow":   time.Now(),
+		"OtherTime": time.Now().Add(time.Hour),
+	}
+	customProps := map[string]interface{}{}
+	startupProps := map[string]interface{}{}
+	beforeStartUseProps := map[string]interface{}{}
+	afterStartUseProps := map[string]interface{}{}
+	afterStartCustomProps := map[string]interface{}{}
+	allSets := map[string]map[string]interface{}{
+		"custom":       customProps,
+		"startup":      startupProps,
+		"before":       beforeStartUseProps,
+		"after":        afterStartUseProps,
+		"after_custom": afterStartCustomProps,
+	}
+	for k, v := range baseProps {
+		for setName, set := range allSets {
+			set[setName+"_"+k] = v
+		}
+	}
+
+	for k, v := range customProps {
+		err = phm.CustomPropertySet(k, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for k, v := range beforeStartUseProps {
+		err := phm.UpdateHistoryForPropertyAccessed(k, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err = db.StartWithPath(dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = phm.TrackPropertyHistoryForStartup(startupProps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for k, v := range afterStartUseProps {
+		err := phm.UpdateHistoryForPropertyAccessed(k, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for k, v := range afterStartCustomProps {
+		err = phm.CustomPropertySet(k, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// retrieve and verify raw from DB
+	r, err := db.sqldb.Query(`
+		SELECT name, type, text_value, int_value, real_value, numeric_value, sample_type FROM property_history 
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	hasRow := r.Next()
+	var n string
+	var rowtype int
+	var tv sql.NullString
+	var rv sql.NullFloat64
+	var iv sql.NullInt64
+	var bv sql.NullBool
+	var s int
+	for hasRow {
+		err = r.Scan(&n, &rowtype, &tv, &iv, &rv, &bv, &s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var val interface{}
+		for _, set := range allSets {
+			v, ok := set[n]
+			if ok {
+				val = v
+				delete(set, n)
+				break
+			}
+		}
+		if val == nil {
+			t.Fatalf("unexpected property %s", n)
+		}
+		if rowtype == int(DBPropertyTypeString) {
+			if !tv.Valid || val != tv.String {
+				t.Fatalf("expected %s, got %s", val, tv.String)
+			}
+			if rv.Valid || iv.Valid || bv.Valid {
+				t.Fatalf("unexpected value")
+			}
+		} else if rowtype == int(DBPropertyTypeInt) {
+			if !iv.Valid || val != int(iv.Int64) {
+				t.Fatalf("expected %d, got %d", val, iv.Int64)
+			}
+			if rv.Valid || tv.Valid || bv.Valid {
+				t.Fatalf("unexpected value")
+			}
+		} else if rowtype == int(DBPropertyTypeFloat) {
+			if !rv.Valid || val != rv.Float64 {
+				t.Fatalf("expected %f, got %f", val, rv.Float64)
+			}
+			if iv.Valid || tv.Valid || bv.Valid {
+				t.Fatalf("unexpected value")
+			}
+		} else if rowtype == int(DBPropertyTypeBool) {
+			if !bv.Valid || val != bv.Bool {
+				t.Fatalf("expected %f, got %v", val, bv.Bool)
+			}
+			if iv.Valid || tv.Valid || rv.Valid {
+				t.Fatalf("unexpected value")
+			}
+		} else if rowtype == int(DBPropertyTypeTime) {
+			vtime, ok := val.(time.Time)
+			if !ok {
+				t.Fatalf("expected time.Time, got %T", val)
+			}
+			if !iv.Valid || vtime.UnixMicro() != iv.Int64 {
+				t.Fatalf("expected %d, got %v", vtime.UnixMicro(), iv.Int64)
+			}
+			if rv.Valid || tv.Valid || bv.Valid {
+				t.Fatalf("unexpected value")
+			}
+		} else {
+			t.Fatalf("unexpected type %d", rowtype)
+		}
+		hasRow = r.Next()
+	}
+
+	for _, set := range allSets {
+		if len(set) != 0 {
+			t.Fatalf("expected all properties to be found")
+		}
+	}
+}
+
+// Benchmark writes. Could batch startup into one transaction, but this is to verify it's not necessary
+// Result: 35k writes/sec and we expect about 30 total so simple approach is great!
+func Benchmark(b *testing.B) {
+	_, phm, err := testPropertyHistoryManager(b)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		x := rand.Int()
+		err = phm.UpdateHistoryForPropertyAccessed(fmt.Sprintf("test%d", x), x)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/go/appcore/property_providers.go
+++ b/go/appcore/property_providers.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	datamodel "github.com/CriticalMoments/CriticalMoments/go/cmcore/data_model"
-	"golang.org/x/exp/slices"
 )
 
 type propertyProvider interface {
@@ -15,26 +14,8 @@ type propertyProvider interface {
 	Kind() reflect.Kind
 }
 
-var validPropertyTypes = []reflect.Kind{
-	reflect.Bool,
-	reflect.String,
-	reflect.Int,
-	reflect.Float64,
-	datamodel.CMTimeKind,
-}
-
 func typeFromValue(v interface{}) reflect.Kind {
-	if v == nil {
-		return reflect.Invalid
-	}
-	if _, ok := v.(time.Time); ok {
-		return datamodel.CMTimeKind
-	}
-	k := reflect.TypeOf(v).Kind()
-	if slices.Contains(validPropertyTypes, k) {
-		return k
-	}
-	return reflect.Invalid
+	return datamodel.CMTypeFromValue(v)
 }
 
 // Set once properties

--- a/go/appcore/property_registry.go
+++ b/go/appcore/property_registry.go
@@ -76,7 +76,7 @@ func (pr *propertyRegistry) addProviderForKey(key string, pp propertyProvider) e
 		}
 	}
 
-	if !slices.Contains(validPropertyTypes, pp.Kind()) {
+	if !slices.Contains(datamodel.ValidPropertyTypes, pp.Kind()) {
 		return errors.New("Invalid property type for key: " + key)
 	}
 

--- a/go/cmcore/data_model/properties.go
+++ b/go/cmcore/data_model/properties.go
@@ -3,9 +3,34 @@ package datamodel
 import (
 	"math"
 	"reflect"
+	"time"
+
+	"golang.org/x/exp/slices"
 )
 
 const CMTimeKind = (reflect.Kind)(math.MaxUint)
+
+var ValidPropertyTypes = []reflect.Kind{
+	reflect.Bool,
+	reflect.String,
+	reflect.Int,
+	reflect.Float64,
+	CMTimeKind,
+}
+
+func CMTypeFromValue(v interface{}) reflect.Kind {
+	if v == nil {
+		return reflect.Invalid
+	}
+	if _, ok := v.(time.Time); ok {
+		return CMTimeKind
+	}
+	k := reflect.TypeOf(v).Kind()
+	if slices.Contains(ValidPropertyTypes, k) {
+		return k
+	}
+	return reflect.Invalid
+}
 
 type CMPropertySampleType int
 


### PR DESCRIPTION
- Decouple creating DB from starting connection. This is so we can cache property writes before startup for the prop history manager
- Move the property type definitions into cmcore.datamodel.properties (where they should have been)
- Update property history schema with types
- Add the property history type, with helpers for the common insert cases, caches, etc
- Test all permutations of property types with sample_type, and when they can be set (before/after startup)
- Add benchmark to see if we want to bundle transaction writes (not needed)