### PR TITLE
Upgrade Macos, xcode, and SDK for unit tests.

### DIFF
--- a/.github/workflows/test_ios.yml
+++ b/.github/workflows/test_ios.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_and_test:
     name: Build & test SDK
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
         run: ./go/build_appcore.sh 
 
       - name: Select xcode
-        run: sudo xcode-select -switch /Applications/Xcode_14.2.app && /usr/bin/xcodebuild -version
+        run: sudo xcode-select -switch /Applications/Xcode_15.2.app && /usr/bin/xcodebuild -version
 
       - name: Build and test iOS Package and SampleApp
-        run: cd ios/sample_app && xcodebuild -scheme SampleApp -testPlan TestPlan -destination 'platform=iOS Simulator,OS=16.2,name=iPhone 14 Pro' -skip-testing:SampleAppTests/SnapshotTests test && cd ../..
+        run: cd ios/sample_app && xcodebuild -scheme SampleApp -testPlan TestPlan -destination 'platform=iOS Simulator,OS=17.2,name=iPhone 14 Pro' -skip-testing:SampleAppTests/SnapshotTests test && cd ../..


### PR DESCRIPTION
The SDK tests don't work on iOS 16.2 (the actual SDK works, fine).

Issue is apple side: https://stackoverflow.com/questions/77448766/app-crashes-when-im-getting-unusernotificationcenter-current-from-into-a-swif